### PR TITLE
Use vega pre-packaged binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 
 # embedded-postgres
 
+This project has been forked from [https://github.com/fergusstrange/embedded-postgres](https://github.com/fergusstrange/embedded-postgres). 
+For Vega Data Node purposes, we need to have access to a postgres database with the TimescaleDB plugin. This requires prebuilt binaries
+that can be found [here](https://github.com/vegaprotocol/embedded-postgres-binaries)
+
+---
+
 Run a real Postgres database locally on Linux, OSX or Windows as part of another Go application or test.
 
 When testing this provides a higher level of confidence than using any in memory alternative. It also requires no other
@@ -29,7 +35,7 @@ embedded-postgres uses Go modules and as such can be referenced by release versi
 following to add the latest release to your project.
 
 ```bash
-go get -u github.com/fergusstrange/embedded-postgres
+go get -u github.com/vegaprotocol/embedded-postgres
 ``` 
 
 ## How to use
@@ -37,11 +43,11 @@ go get -u github.com/fergusstrange/embedded-postgres
 This library aims to require as little configuration as possible, favouring overridable defaults
 
 | Configuration  | Default Value                                   |
-| -------------- | -------------------------------------------     |
+| -------------- |-------------------------------------------------|
 | Username       | postgres                                        |
 | Password       | postgres                                        |
 | Database       | postgres                                        |
-| Version        | 12.1.0                                          |
+| Version        | 14.1.0                                          |
 | RuntimePath    | $USER_HOME/.embedded-postgres-go/extracted      |
 | DataPath       | $USER_HOME/.embedded-postgres-go/extracted/data |
 | BinariesPath   | $USER_HOME/.embedded-postgres-go/extracted      |
@@ -98,7 +104,7 @@ caller will block.
 ## Examples
 
 There are a number of realistic representations of how to use this library
-in [examples](https://github.com/fergusstrange/embedded-postgres/tree/master/examples).
+in [examples](https://github.com/vegaprotocol/embedded-postgres/tree/master/examples).
 
 ## Credits
 

--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ type Config struct {
 // StartTimeout: 15 Seconds
 func DefaultConfig() Config {
 	return Config{
-		version:      V12,
+		version:      V14,
 		port:         5432,
 		database:     "postgres",
 		username:     "postgres",

--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -43,7 +43,7 @@ func newDatabaseWithConfig(config Config) *EmbeddedPostgres {
 		shouldUseAlpineLinuxBuild,
 	)
 	cacheLocator := defaultCacheLocator(versionStrategy)
-	remoteFetchStrategy := defaultRemoteFetchStrategy("https://repo1.maven.org", versionStrategy, cacheLocator)
+	remoteFetchStrategy := defaultRemoteFetchStrategy("https://github.com", "vega-v0.1.0", versionStrategy, cacheLocator)
 
 	return &EmbeddedPostgres{
 		config:              config,

--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -249,7 +249,7 @@ func Test_CustomConfig(t *testing.T) {
 		Username("gin").
 		Password("wine").
 		Database("beer").
-		Version(V12).
+		Version(V14).
 		RuntimePath(tempDir).
 		Port(9876).
 		StartTimeout(10 * time.Second).

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,12 @@
-module github.com/fergusstrange/embedded-postgres
+module github.com/vegaprotocol/embedded-postgres
 
 go 1.13
 
 require (
+	github.com/fergusstrange/embedded-postgres v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.8.0
 	github.com/stretchr/testify v1.6.1
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 )
+
+replace github.com/fergusstrange/embedded-postgres => /home/tanq/code/work/vega/embedded-postgres/feat-use-vega-prepackaged-binaries

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8
 )
 
-replace github.com/fergusstrange/embedded-postgres => /home/tanq/code/work/vega/embedded-postgres/feat-use-vega-prepackaged-binaries
+replace github.com/fergusstrange/embedded-postgres => github.com/vegaprotocol/embedded-postgres v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/vegaprotocol/embedded-postgres v1.13.0 h1:rKwge0S8cfh8KXSFl2gwGRzDIL29efuLvhvpRLgV0Dw=
+github.com/vegaprotocol/embedded-postgres v1.13.0/go.mod h1:tBq6ykQqQoYmhXhdwD9nioMI7L7r7NlVvQtM0ZRfUqs=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/remote_fetch_test.go
+++ b/remote_fetch_test.go
@@ -12,8 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	binaryRepoRelease = "vega-v0.1.0"
+)
+
 func Test_defaultRemoteFetchStrategy_ErrorWhenHttpGet(t *testing.T) {
 	remoteFetchStrategy := defaultRemoteFetchStrategy("http://localhost:1234",
+		binaryRepoRelease,
 		testVersionStrategy(),
 		testCacheLocator())
 
@@ -29,6 +34,7 @@ func Test_defaultRemoteFetchStrategy_ErrorWhenHttpStatusNot200(t *testing.T) {
 	defer server.Close()
 
 	remoteFetchStrategy := defaultRemoteFetchStrategy(server.URL,
+		binaryRepoRelease,
 		testVersionStrategy(),
 		testCacheLocator())
 
@@ -44,6 +50,7 @@ func Test_defaultRemoteFetchStrategy_ErrorWhenBodyReadIssue(t *testing.T) {
 	defer server.Close()
 
 	remoteFetchStrategy := defaultRemoteFetchStrategy(server.URL,
+		binaryRepoRelease,
 		testVersionStrategy(),
 		testCacheLocator())
 
@@ -59,6 +66,7 @@ func Test_defaultRemoteFetchStrategy_ErrorWhenCannotUnzipSubFile(t *testing.T) {
 	defer server.Close()
 
 	remoteFetchStrategy := defaultRemoteFetchStrategy(server.URL,
+		binaryRepoRelease,
 		testVersionStrategy(),
 		testCacheLocator())
 
@@ -76,6 +84,7 @@ func Test_defaultRemoteFetchStrategy_ErrorWhenCannotUnzip(t *testing.T) {
 	defer server.Close()
 
 	remoteFetchStrategy := defaultRemoteFetchStrategy(server.URL,
+		binaryRepoRelease,
 		testVersionStrategy(),
 		testCacheLocator())
 
@@ -95,12 +104,13 @@ func Test_defaultRemoteFetchStrategy_ErrorWhenNoSubTarArchive(t *testing.T) {
 	defer server.Close()
 
 	remoteFetchStrategy := defaultRemoteFetchStrategy(server.URL,
+		binaryRepoRelease,
 		testVersionStrategy(),
 		testCacheLocator())
 
 	err := remoteFetchStrategy()
 
-	assert.EqualError(t, err, "error fetching postgres: cannot find binary in archive retrieved from "+server.URL+"/maven2/io/zonky/test/postgres/embedded-postgres-binaries-darwin-amd64/1.2.3/embedded-postgres-binaries-darwin-amd64-1.2.3.jar")
+	assert.EqualError(t, err, "error fetching postgres: cannot find binary in archive retrieved from "+server.URL+"/vegaprotocol/embedded-postgres-binaries/releases/download/vega-v0.1.0/embedded-postgres-binaries-darwin-amd64-1.2.3.zip")
 }
 
 func Test_defaultRemoteFetchStrategy_ErrorWhenCannotExtractSubArchive(t *testing.T) {
@@ -125,6 +135,7 @@ func Test_defaultRemoteFetchStrategy_ErrorWhenCannotExtractSubArchive(t *testing
 	defer server.Close()
 
 	remoteFetchStrategy := defaultRemoteFetchStrategy(server.URL,
+		binaryRepoRelease,
 		testVersionStrategy(),
 		func() (s string, b bool) {
 			return dirBlockingExtract, false
@@ -160,6 +171,7 @@ func Test_defaultRemoteFetchStrategy_ErrorWhenCannotCreateCacheDirectory(t *test
 	defer server.Close()
 
 	remoteFetchStrategy := defaultRemoteFetchStrategy(server.URL,
+		binaryRepoRelease,
 		testVersionStrategy(),
 		func() (s string, b bool) {
 			return cacheLocation, false
@@ -192,6 +204,7 @@ func Test_defaultRemoteFetchStrategy_ErrorWhenCannotCreateSubArchiveFile(t *test
 	defer server.Close()
 
 	remoteFetchStrategy := defaultRemoteFetchStrategy(server.URL,
+		binaryRepoRelease,
 		testVersionStrategy(),
 		func() (s string, b bool) {
 			return cacheLocation, false
@@ -220,6 +233,7 @@ func Test_defaultRemoteFetchStrategy(t *testing.T) {
 	defer server.Close()
 
 	remoteFetchStrategy := defaultRemoteFetchStrategy(server.URL,
+		binaryRepoRelease,
 		testVersionStrategy(),
 		func() (s string, b bool) {
 			return cacheLocation, false

--- a/version_strategy.go
+++ b/version_strategy.go
@@ -33,6 +33,8 @@ func defaultVersionStrategy(config Config, goos, arch string, linuxMachineName f
 
 			if shouldUseAlpineLinuxBuild() {
 				arch += "-alpine"
+			} else {
+				arch += "-debian"
 			}
 		}
 

--- a/version_strategy_test.go
+++ b/version_strategy_test.go
@@ -25,18 +25,18 @@ func Test_DefaultVersionStrategy_AllGolangDistributions(t *testing.T) {
 		"freebsd/arm64":   {"freebsd", "arm64"},
 		"illumos/amd64":   {"illumos", "amd64"},
 		"js/wasm":         {"js", "wasm"},
-		"linux/386":       {"linux", "386"},
-		"linux/amd64":     {"linux", "amd64"},
-		"linux/arm":       {"linux", "arm"},
-		"linux/arm64":     {"linux", "arm64v8"},
-		"linux/mips":      {"linux", "mips"},
-		"linux/mips64":    {"linux", "mips64"},
-		"linux/mips64le":  {"linux", "mips64le"},
-		"linux/mipsle":    {"linux", "mipsle"},
-		"linux/ppc64":     {"linux", "ppc64"},
-		"linux/ppc64le":   {"linux", "ppc64le"},
-		"linux/riscv64":   {"linux", "riscv64"},
-		"linux/s390x":     {"linux", "s390x"},
+		"linux/386":       {"linux", "386-debian"},
+		"linux/amd64":     {"linux", "amd64-debian"},
+		"linux/arm":       {"linux", "arm-debian"},
+		"linux/arm64":     {"linux", "arm64v8-debian"},
+		"linux/mips":      {"linux", "mips-debian"},
+		"linux/mips64":    {"linux", "mips64-debian"},
+		"linux/mips64le":  {"linux", "mips64le-debian"},
+		"linux/mipsle":    {"linux", "mipsle-debian"},
+		"linux/ppc64":     {"linux", "ppc64-debian"},
+		"linux/ppc64le":   {"linux", "ppc64le-debian"},
+		"linux/riscv64":   {"linux", "riscv64-debian"},
+		"linux/s390x":     {"linux", "s390x-debian"},
 		"netbsd/386":      {"netbsd", "386"},
 		"netbsd/amd64":    {"netbsd", "amd64"},
 		"netbsd/arm":      {"netbsd", "arm"},
@@ -74,7 +74,7 @@ func Test_DefaultVersionStrategy_AllGolangDistributions(t *testing.T) {
 
 			assert.Equal(t, expected[0], operatingSystem)
 			assert.Equal(t, expected[1], architecture)
-			assert.Equal(t, V12, postgresVersion)
+			assert.Equal(t, V14, postgresVersion)
 		})
 	}
 }
@@ -91,8 +91,8 @@ func Test_DefaultVersionStrategy_Linux_ARM32V6(t *testing.T) {
 		})()
 
 	assert.Equal(t, "linux", operatingSystem)
-	assert.Equal(t, "arm32v6", architecture)
-	assert.Equal(t, V12, postgresVersion)
+	assert.Equal(t, "arm32v6-debian", architecture)
+	assert.Equal(t, V14, postgresVersion)
 }
 
 func Test_DefaultVersionStrategy_Linux_ARM32V7(t *testing.T) {
@@ -107,8 +107,8 @@ func Test_DefaultVersionStrategy_Linux_ARM32V7(t *testing.T) {
 		})()
 
 	assert.Equal(t, "linux", operatingSystem)
-	assert.Equal(t, "arm32v7", architecture)
-	assert.Equal(t, V12, postgresVersion)
+	assert.Equal(t, "arm32v7-debian", architecture)
+	assert.Equal(t, V14, postgresVersion)
 }
 
 func Test_DefaultVersionStrategy_Linux_Alpine(t *testing.T) {
@@ -126,7 +126,7 @@ func Test_DefaultVersionStrategy_Linux_Alpine(t *testing.T) {
 
 	assert.Equal(t, "linux", operatingSystem)
 	assert.Equal(t, "amd64-alpine", architecture)
-	assert.Equal(t, V12, postgresVersion)
+	assert.Equal(t, V14, postgresVersion)
 }
 
 func Test_DefaultVersionStrategy_shouldUseAlpineLinuxBuild(t *testing.T) {


### PR DESCRIPTION
Updated the libraries to pull the pre-packaged releases from the Vega embedded-postgres-binaries repo and updated tests to ensure they are all working.