### PR TITLE
Start postgres directly as a child process instead of using pg_ctl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vegaprotocol/embedded-postgres
 go 1.13
 
 require (
+	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/fergusstrange/embedded-postgres v0.0.0-00010101000000-000000000000
 	github.com/lib/pq v1.8.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
+github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=


### PR DESCRIPTION
To ensure embedded postgres stops when the parent process stops, update to execute the postgres executable directly instead of using pg_ctl