### PR TITLE
Ensure timescaledb libraries are preloaded in postgresql.conf

### DIFF
--- a/embedded_postgres_test.go
+++ b/embedded_postgres_test.go
@@ -29,6 +29,10 @@ func Test_DefaultConfig(t *testing.T) {
 		shutdownDBAndFail(t, err, database)
 	}
 
+	if _, err := db.Exec(`create extension if not exists timescaledb`); err != nil {
+		shutdownDBAndFail(t, err, database)
+	}
+
 	if err = db.Ping(); err != nil {
 		shutdownDBAndFail(t, err, database)
 	}


### PR DESCRIPTION
In order to use the timescaledb extension, the timescaledb extensions must be preloaded when Postgres starts. This PR updates the postgres db initialisation and edits the postgresql.conf file to preload these timescaledb libraries.