### PR TITLE
Fix a potential data race

### DIFF
--- a/embedded_postgres.go
+++ b/embedded_postgres.go
@@ -214,9 +214,7 @@ func startPostgres(ep *EmbeddedPostgres) error {
 
 	defer cancel()
 
-	go func() {
-		postgresStartErr = ep.postgresProcess.Run()
-	}()
+	postgresStartErr = ep.postgresProcess.Start()
 
 	for {
 		select {


### PR DESCRIPTION
Which was making `go test --race unhappy`

Use exec.start() instead of using  exec.run() in a goroutine to prevent multiple threads accessing the process object.